### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ Or run it in dev
 yarn tauri dev
 ```
 
-Keep in mind, cause there is sqlcipher you'll need to build opnessl-sys. That takes some time.. 
+Keep in mind, cause there is sqlcipher you'll need to build openssl-sys. That takes some time.. 


### PR DESCRIPTION
## Summary
- fix `opnessl-sys` typo to `openssl-sys` in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840bc1563fc832daf8a6d6608cda633